### PR TITLE
     #3Avoid NULL pointer dereferencing.

### DIFF
--- a/clients/roscpp/src/libros/master.cpp
+++ b/clients/roscpp/src/libros/master.cpp
@@ -75,7 +75,14 @@ void init(const M_string& remappings)
       ROS_BREAK();
     }
 
-    g_uri = master_uri_env;
+    if (master_uri_env)
+    {
+      g_uri = master_uri_env;
+    }
+    else
+    {
+      g_uri = "http://localhost:11311";
+    }
 
 #ifdef _MSC_VER
     // http://msdn.microsoft.com/en-us/library/ms175774(v=vs.80).aspx

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -710,6 +710,12 @@ void TopicManager::publish(const std::string& topic, const boost::function<Seria
   }
 
   PublicationPtr p = lookupPublicationWithoutLock(topic);
+  ROS_ASSERT(p);
+  if (!p)
+  {
+    return;
+  }
+
   if (p->hasSubscribers() || p->isLatching())
   {
     ROS_DEBUG_NAMED("superdebug", "Publishing message on topic [%s] with sequence number [%d]", p->getName().c_str(), p->getSequence());
@@ -780,7 +786,7 @@ bool TopicManager::isLatched(const std::string& topic)
 
 PublicationPtr TopicManager::lookupPublicationWithoutLock(const string &topic)
 {
-  PublicationPtr t;
+  PublicationPtr t = NULL;
   for (V_Publication::iterator i = advertised_topics_.begin();
        !t && i != advertised_topics_.end(); ++i)
   {

--- a/clients/roscpp/src/libros/transport_publisher_link.cpp
+++ b/clients/roscpp/src/libros/transport_publisher_link.cpp
@@ -220,6 +220,11 @@ void TransportPublisherLink::onRetryTimer(const ros::SteadyTimerEvent&)
 
       TransportTCPPtr old_transport = boost::dynamic_pointer_cast<TransportTCP>(connection_->getTransport());
       ROS_ASSERT(old_transport);
+      if (!old_transport)
+      {
+        return;
+      }
+
       const std::string& host = old_transport->getConnectedHost();
       int port = old_transport->getConnectedPort();
 


### PR DESCRIPTION
     Correct the indication by the static analysis tool.
     Avoid NULL pointer dereferencing.