### PR TITLE
 #4 Uninitialized member variables are initialized by the constructor.

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -42,6 +42,10 @@ XmlRpcClient::XmlRpcClient(const char* host, int port, const char* uri/*=0*/)
   _connectionState = NO_CONNECTION;
   _executing = false;
   _eof = false;
+  _isFault = false;
+  _sendAttempts = 0;
+  _bytesWritten = 0;
+  _contentLength = 0;
 
   // Default to keeping the connection open until an explicit close is done
   setKeepOpen();


### PR DESCRIPTION
 Correct the indication by the static analysis tool(Klocwork).
 Uninitialized member variables are initialized by the constructor.