### PR TITLE
 #5  Avoid NULL pointer dereferencing.

### DIFF
--- a/tools/rosconsole/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/tools/rosconsole/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -183,7 +183,7 @@ void print(void* handle, ::ros::console::Level level, const char* str, const cha
 {
   if (handle == NULL)
   {
-    fprintf(stderr, "Log can't output, Logger handle is NULL");
+    fprintf(stderr, "Log can't output, Logger handle is NULL\n");
     return;
   }
   log4cxx::Logger* logger  = (log4cxx::Logger*)handle;

--- a/tools/rosconsole/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/tools/rosconsole/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -181,7 +181,13 @@ void initialize()
 
 void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line)
 {
+  if (handle == NULL)
+  {
+    fprintf(stderr, "Log can't output, Logger handle is NULL");
+    return;
+  }
   log4cxx::Logger* logger  = (log4cxx::Logger*)handle;
+
   try
   {
     logger->forcedLog(g_level_lookup[level], str, log4cxx::spi::LocationInfo(file, function, line));


### PR DESCRIPTION
 Correct the indication by the static analysis tool(Klocwork).
 Avoid NULL pointer dereferencing.