### PR TITLE
 #6  Uninitialized member variables are initialized by the constructor.

### DIFF
--- a/clients/roscpp/include/ros/advertise_options.h
+++ b/clients/roscpp/include/ros/advertise_options.h
@@ -41,8 +41,10 @@ namespace ros
 struct ROSCPP_DECL AdvertiseOptions
 {
   AdvertiseOptions()
-  : callback_queue(0)
+  : queue_size(0)
+  , callback_queue(0)
   , latch(false)
+  , has_header(false)
   {
   }
 


### PR DESCRIPTION
 Correct the indication by the static analysis tool(Klocwork).
 Uninitialized member variables are initialized by the constructor.