### PR TITLE
     #7 Uninitialized member variables are initialized by the constructor.

### DIFF
--- a/clients/roscpp/src/libros/io.cpp
+++ b/clients/roscpp/src/libros/io.cpp
@@ -324,6 +324,7 @@ pollfd_vector_ptr poll_sockets(int epfd, socket_pollfd *fds, nfds_t nfds, int ti
 		{
 			socket_pollfd pfd;
 			pfd.fd = ev[i].data.fd;
+			pfd.events = 0x0000;
 			pfd.revents = ev[i].events;
 			ofds->push_back(pfd);
 		}

--- a/clients/roscpp/src/libros/service_client.cpp
+++ b/clients/roscpp/src/libros/service_client.cpp
@@ -35,7 +35,8 @@ namespace ros
 {
 
 ServiceClient::Impl::Impl() 
-  : is_shutdown_(false)
+  : persistent_(false)
+  , is_shutdown_(false)
 { }
 
 ServiceClient::Impl::~Impl()

--- a/clients/roscpp/src/libros/statistics.cpp
+++ b/clients/roscpp/src/libros/statistics.cpp
@@ -37,7 +37,13 @@ namespace ros
 {
 
 StatisticsLogger::StatisticsLogger()
-: pub_frequency_(1.0)
+: max_window(64)
+, min_window(4)
+, max_elements(100)
+, min_elements(10)
+, enable_statistics(false)
+, hasHeader_(false)
+, pub_frequency_(1.0)
 {
 }
 

--- a/clients/roscpp/src/libros/steady_timer.cpp
+++ b/clients/roscpp/src/libros/steady_timer.cpp
@@ -115,6 +115,9 @@ void TimerManager<SteadyTime, WallDuration, SteadyTimerEvent>::threadFunc()
 SteadyTimer::Impl::Impl()
   : started_(false)
   , timer_handle_(-1)
+  , callback_queue_(0)
+  , has_tracked_object_(false)
+  , oneshot_(false)
 { }
 
 SteadyTimer::Impl::~Impl()

--- a/clients/roscpp/src/libros/timer.cpp
+++ b/clients/roscpp/src/libros/timer.cpp
@@ -34,6 +34,9 @@ namespace ros
 Timer::Impl::Impl()
   : started_(false)
   , timer_handle_(-1)
+  , callback_queue_(0)
+  , has_tracked_object_(false)
+  , oneshot_(false)
 { }
 
 Timer::Impl::~Impl()

--- a/clients/roscpp/src/libros/wall_timer.cpp
+++ b/clients/roscpp/src/libros/wall_timer.cpp
@@ -34,6 +34,9 @@ namespace ros
 WallTimer::Impl::Impl()
   : started_(false)
   , timer_handle_(-1)
+  , callback_queue_(0)
+  , has_tracked_object_(false)
+  , oneshot_(false)
 { }
 
 WallTimer::Impl::~Impl()


### PR DESCRIPTION
     Correct the indication by the static analysis tool(Klocwork).
     Uninitialized member variables are initialized by the constructor.