### PR TITLE
 #8  Uninitialized member variables are initialized by the constructor.

### DIFF
--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -58,8 +58,12 @@ TransportTCP::TransportTCP(PollSet* poll_set, int flags)
 , local_port_(-1)
 , poll_set_(poll_set)
 , flags_(flags)
+, connected_port_(0)
 {
-
+  memset(&server_address_, 0, sizeof(sockaddr_storage));
+  sa_len_ = s_use_ipv6_ ? sizeof(sockaddr_in6) : sizeof(sockaddr_in);
+  memset(&local_address_, 0, sizeof(sockaddr_storage));
+  la_len_ = s_use_ipv6_ ? sizeof(sockaddr_in6) : sizeof(sockaddr_in);
 }
 
 TransportTCP::~TransportTCP()

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -82,6 +82,10 @@ TransportUDP::TransportUDP(PollSet* poll_set, int flags, int max_datagram_size)
   reorder_start_ = reorder_buffer_;
   data_buffer_ = new uint8_t[max_datagram_size_];
   data_start_ = data_buffer_;
+
+  memset(&server_address_, 0, sizeof(sockaddr_in));
+  memset(&local_address_, 0, sizeof(sockaddr_in));
+  memset(&reorder_header_, 0, sizeof(TransportUDPHeader));
 }
 
 TransportUDP::~TransportUDP()


### PR DESCRIPTION
 Correct the indication by the static analysis tool(Klocwork).
 Uninitialized member variables are initialized by the constructor.