### PR TITLE
 #15 infinite loops

### DIFF
--- a/clients/roscpp/include/ros/rosout_appender.h
+++ b/clients/roscpp/include/ros/rosout_appender.h
@@ -74,7 +74,7 @@ protected:
   V_Log log_queue_;
   boost::mutex queue_mutex_;
   boost::condition_variable queue_condition_;
-  bool shutting_down_;
+  volatile bool shutting_down_;
 
   boost::thread publish_thread_;
 };


### PR DESCRIPTION
 Correct the indication by the static analysis tool.
 Avoid infinite loops caused by optimization.