### PR TITLE
 #16 infinite loops

### DIFF
--- a/clients/roscpp/include/ros/xmlrpc_manager.h
+++ b/clients/roscpp/include/ros/xmlrpc_manager.h
@@ -148,7 +148,7 @@ private:
   V_CachedXmlRpcClient clients_;
   boost::mutex clients_mutex_;
 
-  bool shutting_down_;
+  volatile bool shutting_down_;
 
   ros::WallDuration master_retry_timeout_;
 


### PR DESCRIPTION
 Correct the indication by the static analysis tool.
 Avoid infinite loops caused by optimization.