### PR TITLE
 #9  Uninitialized array

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -101,7 +101,7 @@ XmlRpcDispatch::work(double timeout)
     // Construct the sets of descriptors we are interested in
     const unsigned source_cnt = _sources.size();
     pollfd fds[source_cnt];
-    XmlRpcSource * sources[source_cnt];
+    XmlRpcSource * sources[source_cnt] = {};
 
     SourceList::iterator it;
     std::size_t i = 0;


### PR DESCRIPTION
 Correct the indication by the static analysis tool.
 Uninitialized array are initialized.